### PR TITLE
Fix incorrect render of double-width CJK chars

### DIFF
--- a/src/main/java/de/gesundkrank/fzf4j/View.java
+++ b/src/main/java/de/gesundkrank/fzf4j/View.java
@@ -31,6 +31,7 @@ import java.util.stream.IntStream;
 
 import com.googlecode.lanterna.SGR;
 import com.googlecode.lanterna.TerminalPosition;
+import com.googlecode.lanterna.TerminalTextUtils;
 import com.googlecode.lanterna.TextCharacter;
 import com.googlecode.lanterna.TextColor;
 import com.googlecode.lanterna.input.KeyStroke;
@@ -170,6 +171,9 @@ public class View implements AutoCloseable {
                             ));
                 }
 
+                // Offset formed by double-width CJK chars
+                var offset = 0;
+
                 for (var i = 0; i < item.getText().length(); i++) {
                     final TextColor textColor;
                     if (positions != null && posIndex < positions.length
@@ -190,8 +194,11 @@ public class View implements AutoCloseable {
                         character = new TextCharacter(text.charAt(i), textColor, backgroundColor);
                     }
 
-                    textGraphics.setCharacter(2 + i, row, character);
+                    textGraphics.setCharacter(2 + i + offset, row, character);
 
+                    if (TerminalTextUtils.isCharCJK(text.charAt(i))) {
+                        offset += 1;
+                    }
                 }
             }
         });


### PR DESCRIPTION
Hi. Thanks for your library, it helps me to do some useful things. But I noticed that the rendering of CJK characters looks wrong and I think I found a fix for that. Lanterna does render them properly when using `putString`, but not `setCharacter`. Since CJK characters are essentially double-width, we have to take into count the offsets they create to render them properly, which is what `putString` implicitly does, but not `setCharacter`.

Before

![image](https://github.com/gesundkrank/fzf4j/assets/92667539/11cf6460-0294-4c41-a9aa-8b37c0532f98)

After

![image](https://github.com/gesundkrank/fzf4j/assets/92667539/c2357e06-a6a6-4836-88e6-1b29d8920a53)
